### PR TITLE
[#4] docs: Add @mixin shadow for shadow

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -77,3 +77,7 @@
 @mixin rounded-full {
   border-radius: 100px;
 }
+
+@mixin shadow {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}


### PR DESCRIPTION
## 요약 
- 공통으로 적용되는 shadow속성 mixin에 추가

## 변경사항
```css
@mixin shadow {
  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
}

```
- figma를 살펴본 결과 shadow속성은 전부 이것만 사용하는것 같아서 단일 mixin으로 추가하였습니다.
- 혹시라도 추가적인 shadow발견시 변경!

## 이슈번호
#4