### PR TITLE
[#49] message 페이지 layout 작업 (미완)😂

### DIFF
--- a/src/pages/PostPage/MessagePage/InputName.jsx
+++ b/src/pages/PostPage/MessagePage/InputName.jsx
@@ -1,0 +1,12 @@
+import css from './InputName.module.scss';
+
+const InputName = () => {
+  return (
+    <div className={css.box}>
+      <h1 className={css.title}>From.</h1>
+      <input className={css.input} placeholder='이름을 입력해 주세요.' />
+    </div>
+  );
+};
+
+export default InputName;

--- a/src/pages/PostPage/MessagePage/InputName.module.scss
+++ b/src/pages/PostPage/MessagePage/InputName.module.scss
@@ -1,0 +1,30 @@
+@import '../../../styles/index';
+
+.box {
+  display: flex;
+  gap: 0.8rem;
+  flex-direction: column;
+}
+
+.title {
+  color: $gray-900;
+  @include text-2xl;
+  @include font-bold;
+}
+
+.input {
+  display: flex;
+  width: 45rem;
+  padding: 0.7rem 1rem;
+  align-items: center;
+  gap: 0.6rem;
+
+  @include rounded-lg;
+  border: 1px solid $gray-300;
+  background: $white;
+
+  color: $gray-500;
+
+  @include text-base;
+  @include font-normal;
+}

--- a/src/pages/PostPage/MessagePage/Message.jsx
+++ b/src/pages/PostPage/MessagePage/Message.jsx
@@ -1,5 +1,22 @@
+import Button from '../../../components/Button/Button';
+import InputName from './InputName';
+import css from './Message.module.scss';
+import SelectFont from './SelectFont';
+import SelectProfileImage from './SelectPorfileImage';
+import SelectRelationship from './SelectRelationship';
+import TextAreaEditor from './TextAreaEditor';
+
 const Message = () => {
-  return <div>message</div>;
+  return (
+    <section className={css.layout}>
+      <InputName />
+      <SelectProfileImage />
+      <SelectRelationship />
+      <TextAreaEditor />
+      <SelectFont />
+      <Button width={'100%'}>생성하기</Button>
+    </section>
+  );
 };
 
 export default Message;

--- a/src/pages/PostPage/MessagePage/Message.module.scss
+++ b/src/pages/PostPage/MessagePage/Message.module.scss
@@ -1,0 +1,8 @@
+@import '../../../styles/index';
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  padding: 2.9rem 0 3.7rem;
+  gap: 3.1rem;
+}

--- a/src/pages/PostPage/MessagePage/SelectFont.jsx
+++ b/src/pages/PostPage/MessagePage/SelectFont.jsx
@@ -1,0 +1,14 @@
+import Dropdown from '../../../components/Dropdown/Dropdown';
+import css from './SelectFont.module.scss';
+
+const SelectFont = () => {
+  const font = ['Noto Sans'];
+  return (
+    <div className={css.box}>
+      <h1 className={css.title}>폰트 선택</h1>
+      <Dropdown options={font} initialOption='Noto Sans' />
+    </div>
+  );
+};
+
+export default SelectFont;

--- a/src/pages/PostPage/MessagePage/SelectFont.module.scss
+++ b/src/pages/PostPage/MessagePage/SelectFont.module.scss
@@ -1,0 +1,13 @@
+@import '../../../styles/index';
+
+.box {
+  display: flex;
+  gap: 0.8rem;
+  flex-direction: column;
+}
+
+.title {
+  color: $gray-900;
+  @include text-2xl;
+  @include font-bold;
+}

--- a/src/pages/PostPage/MessagePage/SelectPorfileImage.jsx
+++ b/src/pages/PostPage/MessagePage/SelectPorfileImage.jsx
@@ -1,0 +1,30 @@
+import Profile from '../../../components/Profile/Profile';
+import css from './SelectProfileImage.module.scss';
+
+const SelectProfileImage = () => {
+  return (
+    <div className={css.box}>
+      <h1 className={css.title}>프로필 이미지</h1>
+      <div className={css.profileImage}>
+        <Profile className={css.defaultImage} />
+        <div className={css.profileBox}>
+          <h2 className={css.selectProfile}>프로필 이미지를 선택해주세요!</h2>
+          <div className={css.imageList}>
+            <Profile className={css.image} />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+            <Profile />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SelectProfileImage;

--- a/src/pages/PostPage/MessagePage/SelectProfileImage.module.scss
+++ b/src/pages/PostPage/MessagePage/SelectProfileImage.module.scss
@@ -1,0 +1,30 @@
+@import '../../../styles/index';
+
+.profileImage {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.defaultImage {
+  width: 5rem;
+  height: 5rem;
+}
+
+.profileBox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.selectProfile {
+  color: $gray-500;
+
+  @include text-base;
+  @include font-normal;
+}
+
+.imageList {
+  display: flex;
+  gap: 0.3rem;
+}

--- a/src/pages/PostPage/MessagePage/SelectRelationship.jsx
+++ b/src/pages/PostPage/MessagePage/SelectRelationship.jsx
@@ -1,0 +1,14 @@
+import Dropdown from '../../../components/Dropdown/Dropdown';
+import css from './SelectRelationship.module.scss';
+
+const SelectRelationship = () => {
+  const realtionship = ['지인', '친구', '동료', '가족'];
+  return (
+    <div className={css.box}>
+      <h1 className={css.title}>상대와의 관계</h1>
+      <Dropdown initialOption='지인' options={realtionship} />
+    </div>
+  );
+};
+
+export default SelectRelationship;

--- a/src/pages/PostPage/MessagePage/SelectRelationship.module.scss
+++ b/src/pages/PostPage/MessagePage/SelectRelationship.module.scss
@@ -1,0 +1,13 @@
+@import '../../../styles/index';
+
+.box {
+  display: flex;
+  gap: 0.8rem;
+  flex-direction: column;
+}
+
+.title {
+  color: $gray-900;
+  @include text-2xl;
+  @include font-bold;
+}

--- a/src/pages/PostPage/MessagePage/TextAreaEditor.jsx
+++ b/src/pages/PostPage/MessagePage/TextAreaEditor.jsx
@@ -1,0 +1,12 @@
+import css from './TextAreaEditor.module.scss';
+
+const TextAreaEditor = () => {
+  return (
+    <div className={css.box}>
+      <h1 className={css.title}>내용을 입력해 주세요</h1>
+      <div className={css.textArea}></div>
+    </div>
+  );
+};
+
+export default TextAreaEditor;

--- a/src/pages/PostPage/MessagePage/TextAreaEditor.module.scss
+++ b/src/pages/PostPage/MessagePage/TextAreaEditor.module.scss
@@ -1,0 +1,20 @@
+@import '../../../styles/index';
+
+.box {
+  display: flex;
+  gap: 0.8rem;
+  flex-direction: column;
+}
+
+.title {
+  color: $gray-900;
+  @include text-2xl;
+  @include font-bold;
+}
+
+/*NOTE - 임시로 사용 */
+.textArea {
+  width: 100%;
+  height: 16.3rem;
+  border: 1px solid $black;
+}


### PR DESCRIPTION
## 요약
- message page ui layout 작업
- 
## 변경사항

## 📌 원하는 이미지
![2](https://github.com/codeit-sprint4-team9/rolling-paper/assets/105029085/0d5cb660-b54c-43ef-a20f-875c2123d45b)

## 📌현재 이미지

![3](https://github.com/codeit-sprint4-team9/rolling-paper/assets/105029085/a423007c-8262-4ff4-97a2-c0ae28587c73)
![4](https://github.com/codeit-sprint4-team9/rolling-paper/assets/105029085/f42c7429-b141-48e7-9ce1-8a4cc0d4812a)

- [ ] 1. 아래의 본문의 영역에  display:flex / margin / padding 하나만 들어가도 내비게이션이 줄어듭니다
- [ ] 2.  화면 100vh 넘어가면 가로 스크롤이 생깁니다.
- [ ] 3. 프로필 이미지를 줄이는 방법을 찾고 있습니다. / 어떤 이미지를 넣을까요?
- [ ] 4. 드롭다운에 아이콘이 나오지 않습니다. 
- [ ] 5. 드롭다운 리스트가 나오지 않습니다.

📌 1,2 번은 app layout에 적용된 100vw 100vh 없애면 첫번째 올린 이미지처럼 문제 없이 나오긴 합니다.

📌 컴포넌트에 공통으로 들어가는 스타일 어떻게 관리하면 좋을까요?

📌 어떤 텍스트 사용할지?

지나가다 보시고 해결 방법이나 의견 있으시면 댓글 달아주시면 감사하겠습니다 🙏

## 이슈 번호

#49