### PR TITLE
[#42] refactor: ToggleButton 토글처리 state 위치 변경 & preventDefault추가

### DIFF
--- a/src/components/Button/ToggleButton.jsx
+++ b/src/components/Button/ToggleButton.jsx
@@ -1,25 +1,26 @@
-import { useState } from 'react';
 import css from './ToggleButton.module.scss';
 
-const ToggleButton = () => {
-  const [selectedButton, setSelectedButton] = useState('color');
-
-  const handleButtonClick = button => {
+const ToggleButton = ({ selectedButton = 'color', onClick }) => {
+  const handleButtonClick = (option, event) => {
     event.preventDefault();
-    setSelectedButton(prevSelected => (prevSelected === button ? prevSelected : button));
+    if (option !== selectedButton) onClick();
   };
 
   return (
     <section className={css.layout}>
       <button
         className={selectedButton === 'color' ? css.selected : ''}
-        onClick={event => handleButtonClick('color', event)}
+        onClick={event => {
+          handleButtonClick('color', event);
+        }}
       >
         컬러
       </button>
       <button
         className={selectedButton === 'image' ? css.selected : ''}
-        onClick={event => handleButtonClick('image', event)}
+        onClick={event => {
+          handleButtonClick('image', event);
+        }}
       >
         이미지
       </button>


### PR DESCRIPTION
## 요약
- Togglebutton Toggle State 위치 변경
- preventDefault 추가
## 변경 사항
- ToggleButton 컴포넌트 내부에서 토글상태 처리하던것을 외부에서 state의 getter, setter 입력받아 처리하도록 변경
- form안에 버튼 생성시 새로고침 현상 발생을 막기 위해 handleClick에 event.preventDefault 추가
## 이슈 번호
#42 