### PR TITLE
[#78] 프로필 컴포넌트 - 이미지 사이즈를 받을 수 있도록 수정

### DIFF
--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -1,19 +1,26 @@
 import { NONE_PORFILE_IMAGE } from '../../constant/constant';
+import { cn } from '../../utils/classNames';
 import css from './Profile.module.scss';
 
 /**
- * 이미지 url을 받아서 프로필이미지를 생성해줍니다.
- * @param url
- * @returns div
+ * 이미지 imgUrl, size, zIndex를 받아서 프로필이미지를 생성해줍니다.
+ * imgUrl은 필수, 그 외는 선택가능합니다.
+ * @param {,imgUrl, size, zIndex}
+ * @returns
  */
-const Profile = ({ url }) => {
-  const imgUrl = url || NONE_PORFILE_IMAGE;
+const Profile = ({ imgUrl, size, zIndex }) => {
+  let imgUrlPath = imgUrl ?? NONE_PORFILE_IMAGE;
+  zIndex = `zIndex${zIndex}`;
+
+  const imageStatus = imgUrl ? 'profileImage' : 'profileNoneImage';
 
   return (
-    <div className={css.profile}>
-      <img className={url ? css.profileImage : css.profileNoneImage} src={imgUrl} alt='profile' />
-    </div>
+    <img className={cn(css[imageStatus], css[size], css[zIndex])} src={imgUrlPath} alt='profile' />
   );
+};
+
+Profile.defaultProps = {
+  size: 'medium',
 };
 
 export default Profile;

--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -3,24 +3,17 @@ import { cn } from '../../utils/classNames';
 import css from './Profile.module.scss';
 
 /**
- * 이미지 imgUrl, size, zIndex를 받아서 프로필이미지를 생성해줍니다.
- * imgUrl은 필수, 그 외는 선택가능합니다.
- * @param {,imgUrl, size, zIndex}
+ * 이미지 imgUrl, size 받아서 프로필이미지를 생성해줍니다.
+ * imgUrl은 필수, size미입력시 default값 = medium
+ * @param {,imgUrl, size}
  * @returns
  */
-const Profile = ({ imgUrl, size, zIndex }) => {
+const Profile = ({ imgUrl, size = 'medium' }) => {
   let imgUrlPath = imgUrl ?? NONE_PORFILE_IMAGE;
-  zIndex = `zIndex${zIndex}`;
 
   const imageStatus = imgUrl ? 'profileImage' : 'profileNoneImage';
 
-  return (
-    <img className={cn(css[imageStatus], css[size], css[zIndex])} src={imgUrlPath} alt='profile' />
-  );
-};
-
-Profile.defaultProps = {
-  size: 'medium',
+  return <img className={cn(css[imageStatus], css[size])} src={imgUrlPath} alt='profile' />;
 };
 
 export default Profile;

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -28,27 +28,57 @@
     font-size: 1rem;
     border: 0.15rem solid $white;
   }
+
+  &.xSmall {
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 0.15rem solid $white;
+  }
 }
 
-//z-index관리
-.zIndex1 {
-  left: 0;
-  z-index: 1;
+.xSmall {
+  //z-index관리
+  &.zIndex1 {
+    left: 0;
+    z-index: 1;
+  }
+
+  &.zIndex2 {
+    left: 1rem;
+    z-index: 2;
+  }
+
+  &.zIndex3 {
+    left: 2rem;
+    z-index: 3;
+  }
+
+  &.zIndex4 {
+    left: 3rem;
+    z-index: 4;
+  }
 }
 
-.zIndex2 {
-  left: 1.7rem;
-  z-index: 2;
-}
+.small {
+  &.zIndex1 {
+    left: 0;
+    z-index: 1;
+  }
 
-.zIndex3 {
-  left: 3.4rem;
-  z-index: 3;
-}
+  &.zIndex2 {
+    left: 1.3rem;
+    z-index: 2;
+  }
 
-.zIndex4 {
-  left: 5.1rem;
-  z-index: 4;
+  &.zIndex3 {
+    left: 2.6rem;
+    z-index: 3;
+  }
+
+  &.zIndex4 {
+    left: 3.8rem;
+    z-index: 4;
+  }
 }
 
 .profileNoneImage {

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -36,51 +36,6 @@
   }
 }
 
-.xSmall {
-  //z-index관리
-  &.zIndex1 {
-    left: 0;
-    z-index: 1;
-  }
-
-  &.zIndex2 {
-    left: 1rem;
-    z-index: 2;
-  }
-
-  &.zIndex3 {
-    left: 2rem;
-    z-index: 3;
-  }
-
-  &.zIndex4 {
-    left: 3rem;
-    z-index: 4;
-  }
-}
-
-.small {
-  &.zIndex1 {
-    left: 0;
-    z-index: 1;
-  }
-
-  &.zIndex2 {
-    left: 1.3rem;
-    z-index: 2;
-  }
-
-  &.zIndex3 {
-    left: 2.6rem;
-    z-index: 3;
-  }
-
-  &.zIndex4 {
-    left: 3.8rem;
-    z-index: 4;
-  }
-}
-
 .profileNoneImage {
   grid-area: img;
   width: 1.75rem;

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -1,28 +1,60 @@
 @import '../../styles/index';
 
-.profile {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 3.5rem;
-  height: 3.5rem;
-  background-color: $gray-300;
+.profileImage,
+.profileNoneImage {
+  position: absolute;
+  left: 0;
+  z-index: 0;
 
   @include rounded-full;
+
+  // 사이즈 관리
+  &.large {
+    width: 9.3rem;
+    height: 9.3rem;
+  }
+
+  &.medium {
+    width: 5.6rem;
+    height: 5.6rem;
+    margin-right: 0.4rem;
+    border: 0;
+    border-radius: 10rem;
+  }
+
+  &.small {
+    width: 2.25rem;
+    height: 2.25rem;
+    font-size: 1rem;
+    border: 0.15rem solid $white;
+  }
 }
 
-.profileImage {
-  position: absolute;
-  width: 100%;
-  height: 100%;
+//z-index관리
+.zIndex1 {
+  left: 0;
+  z-index: 1;
+}
 
-  @include rounded-full;
+.zIndex2 {
+  left: 1.7rem;
+  z-index: 2;
+}
 
-  object-fit: cover;
+.zIndex3 {
+  left: 3.4rem;
+  z-index: 3;
+}
+
+.zIndex4 {
+  left: 5.1rem;
+  z-index: 4;
 }
 
 .profileNoneImage {
-  width: 1.6rem;
-  height: 1.6rem;
+  grid-area: img;
+  width: 1.75rem;
+  padding: 0.4rem;
+  background-color: $gray-300;
+  background-size: cover;
 }


### PR DESCRIPTION
[#78] 프로필 컴포넌트 - 이미지 사이즈를 받을 수 있도록 수정
# 간단 설명
imgUrl, size를 받아서 프로필 이미지를 만들 수 있습니다. 


# code 일부
`
const Profile = ({ imgUrl, size }) => {
...
return <img />
}`



# 필수값

- imgUrl

# 선택 값
- size  ( default : medium )
  - xSmall : bar- Profiles에 사용. 
  - small : card - Profiles에 사용. 
    - 사이즈와 별개로 테두리 아웃라인이 들어있음 
  - medium : post의 프로필들에 사용
  - large : post의 선택 된 프로필에 사용

# 활용 예시

1. 프로필들에 사용
<img width="310" alt="image" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/101369040/0e8d40bc-7444-4e13-8ec9-1d804688115b">

<img width="333" alt="image" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/101369040/9b57d512-eee6-424d-9ef0-ca02a0f4adb1">



2. POST페이지에 사용
<img width="652" alt="image" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/101369040/e992a692-9adf-4d43-bd52-925794ee53fc">


