### PR TITLE
[#98]OutlinedButton 컴포넌트 기본 값 변경

### DIFF
--- a/src/components/Button/OutlinedButton.jsx
+++ b/src/components/Button/OutlinedButton.jsx
@@ -3,9 +3,9 @@ import css from './OutlinedButton.module.scss';
 
 const OutlinedButton = ({
   isDisabled = false,
-  hasIcon = true,
-  size = 'small',
-  children = 'Enabled',
+  hasIcon = false,
+  size = 'extraLarge',
+  children,
   onClick,
 }) => {
   return (


### PR DESCRIPTION
### 요약
* hasIcon : true -> false 변경
* size : small -> extraLarge 변경

emoji 작업하다가 확인해보니까 OutlinedButton 컴포넌트 만들면서 테스트 하다가 마지막 테스트 값을 기본값으로 해놨더라고요 !!??
hasIcon은 아이콘을 사용하는 부분에서 직접 hasIcon = true 을 prop으로 주는 게 더 직관적으로 보이고 사이즈는 아이콘을 사용하지 않는 extraLarge로 변경해놨습니당
만약 이모지 사용 안 하신다면 걍 children이랑 onClick만 보내주면 됨미다 😉 예를 들어 Header 작업할 때 ! 