### PR TITLE
[#105] fix : 프로필 그룹 기본값 빈배열 셋팅

### DIFF
--- a/src/components/Profiles/Profiles.jsx
+++ b/src/components/Profiles/Profiles.jsx
@@ -11,7 +11,7 @@ import css from './Profiles.module.scss';
  * - size : xSmall, small
  */
 
-const Profiles = ({ profileList, size = 'small' }) => {
+const Profiles = ({ profileList = [], size = 'small' }) => {
   return (
     <div className={css.profilesArea}>
       {profileList.slice(0, 3).map(profile => (


### PR DESCRIPTION
# 이슈 [#105]
프로필 그룹 컴포넌트에 값이 존재 하지 않는 경우 에러가 발생되는 현상

# 수정
프로필 리스트가 들어오지 않는 경우 기본값은 빈 배열로 셋팅