### PR TITLE
[#107]OutlinedButton 컴포넌트 common-style 수정

### DIFF
--- a/src/components/Button/DeletedButton.module.scss
+++ b/src/components/Button/DeletedButton.module.scss
@@ -1,6 +1,7 @@
 @import './OutlinedButton.module';
 
 .deleted {
+  @extend .outlinedButtonStyle;
   @include rounded-sm;
 
   padding: 0.4rem;

--- a/src/components/Button/OutlinedButton.module.scss
+++ b/src/components/Button/OutlinedButton.module.scss
@@ -6,7 +6,7 @@
   justify-content: center;
   color: $gray-900;
   background: $white;
-  border: 0.1rem solid $gray-300;
+  border: 1px solid $gray-300;
 
   &:disabled {
     color: $white;
@@ -42,7 +42,6 @@
     @include font-bold;
 
     width: 10rem;
-    letter-spacing: -0.1rem;
   }
 }
 
@@ -58,7 +57,6 @@
     @include font-normal;
 
     // width: 5.6rem;
-    letter-spacing: -0.01rem;
   }
 }
 
@@ -94,6 +92,5 @@
     @include font-normal;
 
     // width: 5.6rem;
-    letter-spacing: -0.01rem;
   }
 }

--- a/src/components/Button/OutlinedButton.module.scss
+++ b/src/components/Button/OutlinedButton.module.scss
@@ -1,6 +1,6 @@
 @import '../../styles/index';
 
-button {
+.outlinedButtonStyle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -32,6 +32,7 @@ button {
 }
 
 .extraLarge {
+  @extend .outlinedButtonStyle;
   @include rounded-xl;
 
   padding: 0.8rem 1rem;
@@ -46,6 +47,7 @@ button {
 }
 
 .large {
+  @extend .outlinedButtonStyle;
   @include rounded-sm;
 
   gap: 0.6rem;
@@ -61,6 +63,7 @@ button {
 }
 
 .medium {
+  @extend .outlinedButtonStyle;
   @include rounded-sm;
 
   gap: 0.2rem;
@@ -75,6 +78,7 @@ button {
 }
 
 .small {
+  @extend .outlinedButtonStyle;
   @include rounded-sm;
 
   gap: 0.2rem;


### PR DESCRIPTION
### 요약
* button 태그 선택자로 common style을 줬을 때 다른 button과 겹치는 문제 
-> outlinedButtonStyle 클래스 사용해서 common style 적용
```javascript
.outlinedButtonStyle {
  ...
}

.extraLarge {
  @extend .outlinedButtonStyle;
  ...
}
``` 

* letter-spacing 삭제, border 단위 수정