### PR TITLE
[#108]Homepage 반응형

### DIFF
--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -19,7 +19,7 @@ const Home = () => {
       ))}
       <Link to='/list'>
         <div className={css.listLinkButton}>
-          <Button>구경해보기</Button>
+          <Button width={'100%'}>구경해보기</Button>
         </div>
       </Link>
     </section>

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -1,14 +1,13 @@
 import { Link } from 'react-router-dom';
 import Button from '../../components/Button/Button';
 import { HOME_ARTICLE_LIST } from '../../constant/constant';
-import { cn } from '../../utils/classNames';
 import css from './Home.module.scss';
 
 const Home = () => {
   return (
     <section className={css.layout}>
       {HOME_ARTICLE_LIST.map(({ id, title, description, image }) => (
-        <article key={id} className={cn(css[`point${id}`])}>
+        <article key={id} className={css.homeArticle}>
           <div className={css.textBox}>
             <p className={css.pointNumber}>Point. {id}</p>
             <h1 className={css.title}>{title}</h1>

--- a/src/pages/HomePage/Home.jsx
+++ b/src/pages/HomePage/Home.jsx
@@ -14,11 +14,13 @@ const Home = () => {
             <h1 className={css.title}>{title}</h1>
             <p className={css.description}>{description}</p>
           </div>
-          <img className={css.mainImage} src={image} alt='롤링 소개 이미지' />
+          <img className={css.articleImage} src={image} alt='롤링 소개 이미지' />
         </article>
       ))}
       <Link to='/list'>
-        <Button width={'280px'}>구경해보기</Button>
+        <div className={css.listLinkButton}>
+          <Button>구경해보기</Button>
+        </div>
       </Link>
     </section>
   );

--- a/src/pages/HomePage/Home.module.scss
+++ b/src/pages/HomePage/Home.module.scss
@@ -1,13 +1,25 @@
 @import '../../styles/index';
 
-.common-style {
+.homeArticleStyle {
   @include rounded-2xl;
 
   display: flex;
-  width: 60rem;
+  max-width: 72.5rem;
+  width: 100%;
   background: $surface;
-  gap: 0.6rem;
-  padding: 5rem;
+  padding: 4rem 3rem;
+
+  @media (max-width: 1199px) {
+    padding: 2rem;
+    flex-direction: column;
+    min-width: 45rem;
+    gap: 3.1rem;
+  }
+
+  @media (max-width: 767px) {
+    padding: 1.5rem;
+    min-width: 20rem;
+  }
 }
 
 .layout {
@@ -17,23 +29,35 @@
   flex-direction: column;
   align-items: center;
   gap: 1.9rem;
+  padding: 0 1.5rem;
+
+  @media (max-width: 1199px) {
+    margin-bottom: 6.9rem;
+  }
 
   .point01 {
-    @extend .common-style;
+    @extend .homeArticleStyle;
 
-    flex-direction: row;
+    @media (min-width: 1200px) {
+      flex-direction: row;
+    }
   }
 
   .point02 {
-    @extend .common-style;
+    @extend .homeArticleStyle;
 
-    flex-direction: row-reverse;
+    @media (min-width: 1200px) {
+      flex-direction: row-reverse;
+    }
   }
 
-  .mainImage {
+  .articleImage {
     display: flex;
     width: 45rem;
-    height: 12rem;
+
+    @media (max-width: 1199px) {
+      width: 100%;
+    }
   }
 
   .textBox {
@@ -61,6 +85,10 @@
       font-style: normal;
       margin-top: 1rem;
       margin-bottom: 0.2rem;
+
+      @media (max-width: 767px) {
+        @include text-lg;
+      }
     }
 
     .description {
@@ -69,12 +97,22 @@
 
       color: $gray-500;
       font-style: normal;
+
+      @media (max-width: 767px) {
+        @include text-sm;
+      }
     }
   }
 
-  Button {
+  .listLinkButton {
     position: fixed;
     bottom: 2.5rem;
     transform: translateX(-50%);
+    width: 17.5rem;
+
+    @media (max-width: 1199px) {
+      padding: 0 1.5rem;
+      width: 100%;
+    }
   }
 }

--- a/src/pages/HomePage/Home.module.scss
+++ b/src/pages/HomePage/Home.module.scss
@@ -4,32 +4,32 @@
   @include rounded-2xl;
 
   display: flex;
-  max-width: 72.5rem;
   width: 100%;
-  background: $surface;
+  max-width: 72.5rem;
   padding: 4rem 3rem;
+  background: $surface;
 
   @media (max-width: 1199px) {
-    padding: 2rem;
     flex-direction: column;
-    min-width: 45rem;
     gap: 3.1rem;
+    min-width: 45rem;
+    padding: 2rem;
   }
 
   @media (max-width: 767px) {
-    padding: 1.5rem;
     min-width: 20rem;
+    padding: 1.5rem;
   }
 }
 
 .layout {
-  margin-top: 3rem;
-  background: $white;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 1.9rem;
+  align-items: center;
   padding: 0 1.5rem;
+  margin-top: 3rem;
+  background: $white;
 
   @media (max-width: 1199px) {
     margin-bottom: 6.9rem;
@@ -70,21 +70,21 @@
       @include font-bold;
 
       display: flex;
-      border-radius: 50px;
-      background: $purple-600;
       padding: 0.4rem 0.8rem;
       font-style: normal;
       color: $white;
+      background: $purple-600;
+      border-radius: 50px;
     }
 
     .title {
       @include text-2xl;
       @include font-bold;
 
-      color: $gray-900;
-      font-style: normal;
       margin-top: 1rem;
       margin-bottom: 0.2rem;
+      font-style: normal;
+      color: $gray-900;
 
       @media (max-width: 767px) {
         @include text-lg;
@@ -95,8 +95,8 @@
       @include text-lg;
       @include font-normal;
 
-      color: $gray-500;
       font-style: normal;
+      color: $gray-500;
 
       @media (max-width: 767px) {
         @include text-sm;
@@ -107,12 +107,12 @@
   .listLinkButton {
     position: fixed;
     bottom: 2.5rem;
-    transform: translateX(-50%);
     width: 17.5rem;
+    transform: translateX(-50%);
 
     @media (max-width: 1199px) {
-      padding: 0 1.5rem;
       width: 100%;
+      padding: 0 1.5rem;
     }
   }
 }

--- a/src/pages/HomePage/Home.module.scss
+++ b/src/pages/HomePage/Home.module.scss
@@ -35,7 +35,7 @@
     margin-bottom: 6.9rem;
   }
 
-  .point01 {
+  .homeArticle:nth-child(odd) {
     @extend .homeArticleStyle;
 
     @media (min-width: 1200px) {
@@ -43,7 +43,7 @@
     }
   }
 
-  .point02 {
+  .homeArticle:nth-child(even) {
     @extend .homeArticleStyle;
 
     @media (min-width: 1200px) {

--- a/src/pages/HomePage/Home.module.scss
+++ b/src/pages/HomePage/Home.module.scss
@@ -6,12 +6,12 @@
   display: flex;
   width: 100%;
   max-width: 75rem;
-  padding: 3rem 4.5rem;
+  padding: 3rem 5rem;
   background: $surface;
 
   @media (max-width: 1199px) {
     flex-direction: column;
-    gap: 3.1rem;
+    gap: 2.5rem;
     min-width: 45rem;
     padding: 2rem;
   }

--- a/src/pages/HomePage/Home.module.scss
+++ b/src/pages/HomePage/Home.module.scss
@@ -5,8 +5,8 @@
 
   display: flex;
   width: 100%;
-  max-width: 72.5rem;
-  padding: 4rem 3rem;
+  max-width: 75rem;
+  padding: 3rem 4.5rem;
   background: $surface;
 
   @media (max-width: 1199px) {


### PR DESCRIPTION
### 요약
* Homepage 반응형 구현

## PC (1200px :arrow_up:)
<img width="1440" alt="스크린샷 2024-03-08 오전 11 48 25" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/155047307/159066c5-3226-4ec8-a868-b94c3ffa9d96">

## Tablet (768px - 1199px)
<img width="785" alt="스크린샷 2024-03-08 오전 11 31 12" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/155047307/fd3e9928-9748-428b-9011-9bf81229d854">

## Mobile (767px :arrow_down:)
<img width="500" alt="스크린샷 2024-03-08 오전 11 31 37" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/155047307/1408dca3-c741-4157-9e85-1df6aaaf113c">

---
## 이슈번호
#108