### PR TITLE
[#75] refactor: Modify submit action(navigtae to post/id)

### DIFF
--- a/src/pages/PostPage/NewPost/NewPost.jsx
+++ b/src/pages/PostPage/NewPost/NewPost.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Button from '../../../components/Button/Button';
 import ToggleButton from '../../../components/Button/ToggleButton';
 import Input from '../../../components/Input/Input';
@@ -8,13 +9,14 @@ import css from './NewPost.module.scss';
 import OptionCardList from './OptionCardList/OptionCardList';
 
 const NewPost = () => {
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+
   const [inputValue, setInputValue] = useState('');
   const [selectedButton, setSelectedButton] = useState('color');
   const [selectedOption, setSelectedOption] = useState(0);
   const [isInputError, setIsInputError] = useState(false);
-  // const [image, setImage] = useState(null);
   const [cardList, setCardList] = useState(BACKGROUND_COLOR_LIST);
-  const fileInputRef = useRef(null);
 
   const handleInputChange = value => {
     setInputValue(value);
@@ -52,11 +54,10 @@ const NewPost = () => {
       backgroundImageURL:
         selectedButton === 'color' ? null : BACKGROUND_IMAGE_URL_LIST[selectedOption],
     };
-    console.log(postData);
 
     try {
       const result = await axios.post('/recipients/', postData);
-      console.log(result);
+      navigate(`/post/${result.data.id}`);
     } catch (error) {
       console.error(error);
     }

--- a/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.jsx
+++ b/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.jsx
@@ -2,12 +2,10 @@ import { cn } from '../../../../utils/classNames';
 import OptionCard from '../OptionCard/OptionCard';
 import css from './OptionCardList.module.scss';
 
-const OptionCardList = ({ cardList, selectedButton, selectedOption, onClick }) => {
-  const topCards = cardList.slice(0, 4);
-  console.log(topCards);
+const OptionCardList = ({ cardList = [], selectedButton, selectedOption, onClick }) => {
   return (
     <ul className={css.layout}>
-      {topCards.map((card, index) => (
+      {cardList.map((card, index) => (
         <li
           className={cn(selectedOption === index && css.selected)}
           key={index}


### PR DESCRIPTION
## 요약
- 롤링페이퍼 생성시 생성후 /id로 페이지 이동 설정
## 변경사항
- react-router-dom의 useNavigator사용
-` nvagiate(`/post/${data.results.id}`)`
##이슈번호
#75 