### PR TITLE
[#118] Feat:  post/id/edit 페이지 구현

### DIFF
--- a/public/assets/rotate.svg
+++ b/public/assets/rotate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z"/>
+  <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466"/>
+</svg>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -15,7 +15,6 @@ const AppRouter = () => {
           <Route path='/list' element={<List />} />
           <Route path='/post' element={<NewPost />} />
           <Route path='/post/:id' element={<Post />} />
-          <Route path='/post/:id/edit' element={<Post />} />
           <Route path='/post/:id/message' element={<Message />} />
         </Route>
       </Routes>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -2,7 +2,6 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import App from './App';
 import Home from './pages/HomePage/Home';
 import List from './pages/ListPage/List';
-import Edit from './pages/PostPage/EditPage/Edit';
 import Message from './pages/PostPage/MessagePage/Message';
 import NewPost from './pages/PostPage/NewPost/NewPost';
 import Post from './pages/PostPage/UserPost/Post';
@@ -16,7 +15,7 @@ const AppRouter = () => {
           <Route path='/list' element={<List />} />
           <Route path='/post' element={<NewPost />} />
           <Route path='/post/:id' element={<Post />} />
-          <Route path='/post/:id/edit' element={<Edit />} />
+          <Route path='/post/:id/edit' element={<Post />} />
           <Route path='/post/:id/message' element={<Message />} />
         </Route>
       </Routes>

--- a/src/components/Carousel/Carousel.module.scss
+++ b/src/components/Carousel/Carousel.module.scss
@@ -10,7 +10,6 @@
 
 .slides {
   display: flex;
-
   transition: transform 0.5s ease;
 }
 
@@ -22,16 +21,16 @@
 .leftButton,
 .rightButton {
   position: absolute;
-  transform: translateY(-50%);
   top: 50%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  background-color: $white;
-  border: 1px solid $gray-400;
-  border-radius: 50%;
   width: 2rem;
   height: 2rem;
+  cursor: pointer;
+  background: none;
+  background-color: $white;
+  border: none;
+  border: 1px solid $gray-400;
+  border-radius: 50%;
+  transform: translateY(-50%);
 }
 
 .leftButton {

--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -35,7 +35,7 @@
   padding: 0.8rem 1rem;
 }
 
-@media (min-width: 767px) and (max-width: 1024px) {
+@media (width >= 767px) and (width <= 1024px) {
   .tablet {
     position: relative;
   }

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -11,22 +11,20 @@
 
 .headerContents {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   width: 75.44rem;
   height: 2.5rem;
-  align-items: center;
 }
 
 .logoArea {
   display: flex;
+  flex-flow: column wrap;
   gap: 0.5rem;
   align-items: center;
+  justify-content: center;
   width: 6.6rem;
   height: 1.9rem;
-
-  flex-wrap: wrap;
-  flex-direction: column;
-  justify-content: center;
 }
 
 .logo {

--- a/src/components/Profile/Profile.module.scss
+++ b/src/components/Profile/Profile.module.scss
@@ -39,7 +39,7 @@
     border: 0;
     border-radius: 10rem;
 
-    @media screen and (max-width: 767px) {
+    @media screen and (width <= 767px) {
       width: 2.25rem;
       height: 2.25rem;
     }

--- a/src/constant/constant.js
+++ b/src/constant/constant.js
@@ -8,6 +8,7 @@ export const ARROW_UP_ICON = '/assets/arrow_up.svg';
 export const ARROW_DOWN_ICON = '/assets/arrow_down.svg';
 export const ARROW_LEFT_ICON = '/assets/arrow_left.svg';
 export const ARROW_RIGHT_ICON = '/assets/arrow_right.svg';
+export const ARROW_ROTATE_ICON = '/assets/rotate.svg';
 
 export const EMOJI_ICON_PATH = '/assets/add-lg.svg';
 export const EMOJI_WHITE_ICON_PATH = '/assets/add-lg-white.svg';
@@ -58,16 +59,15 @@ export const SHARE_OPTION_LIST = [
 ];
 export const WEB_URL = 'https://www.naver.com';
 
-
 export const PROFILE_IMAGE_URL_LIST = [
-  "https://learn-codeit-kr-static.s3.ap-northeast-2.amazonaws.com/sprint-proj-image/default_avatar.png",
-        "https://picsum.photos/id/522/100/100",
-        "https://picsum.photos/id/547/100/100",
-        "https://picsum.photos/id/268/100/100",
-        "https://picsum.photos/id/1082/100/100",
-        "https://picsum.photos/id/571/100/100",
-        "https://picsum.photos/id/494/100/100",
-        "https://picsum.photos/id/859/100/100",
-        "https://picsum.photos/id/437/100/100",
-        "https://picsum.photos/id/1064/100/100"
-]
+  'https://learn-codeit-kr-static.s3.ap-northeast-2.amazonaws.com/sprint-proj-image/default_avatar.png',
+  'https://picsum.photos/id/522/100/100',
+  'https://picsum.photos/id/547/100/100',
+  'https://picsum.photos/id/268/100/100',
+  'https://picsum.photos/id/1082/100/100',
+  'https://picsum.photos/id/571/100/100',
+  'https://picsum.photos/id/494/100/100',
+  'https://picsum.photos/id/859/100/100',
+  'https://picsum.photos/id/437/100/100',
+  'https://picsum.photos/id/1064/100/100',
+];

--- a/src/pages/ListPage/Card/Card.module.scss
+++ b/src/pages/ListPage/Card/Card.module.scss
@@ -1,53 +1,53 @@
 @import '../../../styles/index';
 
 .cardArea {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   width: 17.19rem;
   height: 16.25rem;
-  @include rounded-2xl;
-  border: 0.06rem;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
   padding: 0.63rem;
+  border: 0.06rem;
 
-  position: relative;
+  @include rounded-2xl;
 }
 
 .cardLayerArea {
-  width: 17.19rem;
-  height: 16.25rem;
-  @include rounded-2xl;
   position: absolute;
   top: 0;
   left: 0;
+  width: 17.19rem;
+  height: 16.25rem;
+
+  @include rounded-2xl;
 
   &.white {
     background-color: $black;
-    opacity: 30%;
+    opacity: 0.3;
   }
 }
 
 .contents {
+  position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
   width: 90%;
   height: 70%;
-  display: flex;
-  position: relative;
-  flex-wrap: nowrap;
-  flex-direction: column;
-  justify-content: center;
 }
 
 .titie {
+  margin: 0.82rem 0 0.44rem;
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 2.25rem;
   text-align: left;
-  margin: 0.82rem 0 0.44rem;
 }
 
 .writerCount {
-  margin: 0.44rem 0 0.63rem;
   display: flex;
+  margin: 0.44rem 0 0.63rem;
   font-family: Pretendard;
   font-size: 1rem;
   font-weight: 400;
@@ -64,17 +64,17 @@
 }
 
 .line {
-  opacity: 30%;
   height: 0.94rem;
   border-bottom: 0.15rem solid $white;
+  opacity: 0.3;
 }
 
 .emojiArea {
+  z-index: 1;
   display: flex;
   gap: 0.63rem;
   height: 2.5rem;
   margin-top: 0.63rem;
-  z-index: 1;
 }
 
 .white {

--- a/src/pages/ListPage/List.module.scss
+++ b/src/pages/ListPage/List.module.scss
@@ -9,19 +9,19 @@
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 2.25rem;
-  letter-spacing: -0.01em;
   text-align: left;
+  letter-spacing: -0.01em;
 }
 
 .paperList {
-  width: 100%;
-  margin: 1.5rem 0;
   display: flex;
   gap: 20px;
+  width: 100%;
+  margin: 1.5rem 0;
 }
 
 .buttomArea {
-  margin: 3rem;
   display: flex;
   justify-content: center;
+  margin: 3rem;
 }

--- a/src/pages/PostPage/EditPage/Edit.jsx
+++ b/src/pages/PostPage/EditPage/Edit.jsx
@@ -1,5 +1,0 @@
-const Edit = () => {
-  return <div>Edit</div>;
-};
-
-export default Edit;

--- a/src/pages/PostPage/MessagePage/FontPicker/FontPicker.module.scss
+++ b/src/pages/PostPage/MessagePage/FontPicker/FontPicker.module.scss
@@ -2,7 +2,7 @@
 @import '../mixins';
 @include form-box;
 
-@media screen and (max-width: 767px) {
+@media screen and (width <= 767px) {
   .box {
     margin-bottom: 11.5rem;
   }

--- a/src/pages/PostPage/MessagePage/Message.module.scss
+++ b/src/pages/PostPage/MessagePage/Message.module.scss
@@ -5,13 +5,13 @@
   display: flex;
   flex-direction: column;
   gap: 3.1rem;
-  max-width: 45rem;
   width: 100%;
+  max-width: 45rem;
   padding: 2.9rem 0 3.7rem;
 
-  @media screen and (max-width: 767px) {
+  @media screen and (width <= 767px) {
     min-width: 20rem;
-    padding: 3.125rem 3.125rem;
+    padding: 3.125rem;
   }
 }
 

--- a/src/pages/PostPage/MessagePage/ProfileImagePicker/ProfileImagePicker.module.scss
+++ b/src/pages/PostPage/MessagePage/ProfileImagePicker/ProfileImagePicker.module.scss
@@ -30,7 +30,7 @@
   display: flex;
   gap: 0.3rem;
 
-  @media screen and (max-width: 767px) {
+  @media screen and (width <= 767px) {
     flex-wrap: wrap;
     gap: 0.1rem;
   }
@@ -43,12 +43,12 @@
 .profileButton {
   position: relative;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   padding: 0;
-  border: none;
-  background-color: transparent;
   cursor: pointer;
+  background-color: transparent;
+  border: none;
 
   &:hover,
   &:focus {
@@ -56,13 +56,13 @@
   }
 
   &::after {
-    content: ' ';
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%);
     width: 1.5rem;
     height: 1.5rem;
+    content: ' ';
+    transform: translate(-50%, -50%);
   }
 
   &:focus::after {
@@ -71,7 +71,7 @@
     background-size: contain;
   }
 
-  @media screen and (max-width: 767px) {
+  @media screen and (width <= 767px) {
     width: 2.5rem;
 
     &::after {
@@ -81,7 +81,7 @@
   }
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (width <= 767px) {
   .imageList {
     flex-wrap: wrap;
     gap: 0.1rem;

--- a/src/pages/PostPage/MessagePage/TextAreaEditor/TextAreaEditor.module.scss
+++ b/src/pages/PostPage/MessagePage/TextAreaEditor/TextAreaEditor.module.scss
@@ -1,4 +1,3 @@
 @import '../../../../styles/index';
 @import '../mixins';
-
 @include form-box;

--- a/src/pages/PostPage/MessagePage/TextAreaEditor/quill.scss
+++ b/src/pages/PostPage/MessagePage/TextAreaEditor/quill.scss
@@ -1,17 +1,17 @@
 :root {
   .ql-toolbar {
+    height: 3rem;
+    padding: 0.8rem 1rem;
+    background-color: #eee;
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
-    height: 3rem;
-    background-color: #eee;
-    padding: 0.8rem 1rem;
   }
 
   .ql-container {
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
     height: 15.6rem;
     padding: 1rem;
+    border-bottom-right-radius: 8px;
+    border-bottom-left-radius: 8px;
   }
 
   strong {

--- a/src/pages/PostPage/UserPost/CardList/Card.jsx
+++ b/src/pages/PostPage/UserPost/CardList/Card.jsx
@@ -1,22 +1,67 @@
+import { useState } from 'react';
 import Badge from '../../../../components/Badge/Badge';
 import Profile from '../../../../components/Profile/Profile';
+import { DELETE_ICON_PATH } from '../../../../constant/constant';
+import { ARROW_ROTATE_ICON } from '../../../../constant/constant';
+import { cn } from '../../../../utils/classNames';
 import { createdDate } from '../../../../utils/createdDate';
 import css from './Card.module.scss';
 
-const Card = ({ content, createdAt, font, profileImageURL, relationship, sender, onClick }) => {
+const Card = ({
+  id,
+  content,
+  createdAt,
+  font,
+  profileImageURL,
+  relationship,
+  sender,
+  onClick,
+  onAddId,
+  selectedMessageIdList,
+  isEditing,
+}) => {
+  const [isSelected, setIsSelected] = useState(false);
+  const selectedCardClassName = cn(css.layout, isSelected && css.selected);
+
   const fontStyle = {
     fontFamily: font,
   };
+
+  const handleDeletedIdList = id => {
+    if (selectedMessageIdList.includes(id)) {
+      const newIdList = selectedMessageIdList.filter(prevId => prevId !== id);
+      onAddId(newIdList);
+    } else {
+      onAddId([...selectedMessageIdList, id]);
+    }
+  };
+
   return (
-    <div className={css.layout} onClick={onClick}>
+    <div className={selectedCardClassName} onClick={onClick}>
       <section className={css.header}>
         <Profile imgUrl={profileImageURL} />
         <div className={css.profile}>
-          <p>
-            From. <span className={css.name}>{sender}</span>
+          <p className={css.name}>
+            <span className={css.from}>From.</span> {sender}
           </p>
           <Badge relationship={relationship} />
         </div>
+        {isEditing && (
+          <div
+            className={css.deleteButton}
+            onClick={e => {
+              e.stopPropagation();
+              handleDeletedIdList(id);
+              setIsSelected(!isSelected);
+            }}
+          >
+            {isSelected ? (
+              <img src={ARROW_ROTATE_ICON} alt='되돌리기' />
+            ) : (
+              <img src={DELETE_ICON_PATH} alt='삭제' />
+            )}
+          </div>
+        )}
       </section>
       <div className={css.divider} />
       <div className={css.content}>

--- a/src/pages/PostPage/UserPost/CardList/Card.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/Card.module.scss
@@ -15,6 +15,10 @@
   @include shadow;
 }
 
+.selected {
+  opacity: 0.6;
+}
+
 .header {
   display: flex;
   gap: 0.8rem;
@@ -28,12 +32,37 @@
   gap: 0.375rem;
   align-items: flex-start;
   color: $black;
+  width: 13rem;
+  white-space: wrap;
 
   @include text-xl;
 }
 
 .name {
+  width: 13rem;
+  overflow-wrap: break-word;
   @include font-bold;
+}
+
+.from {
+  @include font-normal;
+}
+
+.deleteButton {
+  min-width: 2rem;
+  height: 2rem;
+  border-radius: 0.375rem;
+  border: 1px solid $gray-300;
+  background: $white;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: auto;
+}
+
+.deleteButton:hover {
+  background-color: $gray-100;
 }
 
 .divider {
@@ -44,12 +73,10 @@
 
 .content {
   width: 100%;
-  height: 100%;
   padding: 0 1rem;
-  overflow: hidden;
   color: $gray-600;
-  text-overflow: ellipsis;
-  white-space: wrap;
+  word-wrap: break-word;
+  overflow: auto;
 
   @include text-lg;
 }
@@ -57,6 +84,7 @@
 .createdAt {
   width: 100%;
   padding: 0 1rem 1rem;
+  margin-top: auto;
   color: $gray-400;
 
   @include text-2xs;

--- a/src/pages/PostPage/UserPost/CardList/Card.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/Card.module.scss
@@ -8,8 +8,8 @@
   align-items: center;
   width: 24rem;
   height: 17.5rem;
-  background: $white;
   cursor: pointer;
+  background: $white;
 
   @include rounded-2xl;
   @include shadow;
@@ -31,8 +31,8 @@
   flex-direction: column;
   gap: 0.375rem;
   align-items: flex-start;
-  color: $black;
   width: 13rem;
+  color: $black;
   white-space: wrap;
 
   @include text-xl;
@@ -41,6 +41,7 @@
 .name {
   width: 13rem;
   overflow-wrap: break-word;
+
   @include font-bold;
 }
 
@@ -49,16 +50,15 @@
 }
 
 .deleteButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   min-width: 2rem;
   height: 2rem;
-  border-radius: 0.375rem;
-  border: 1px solid $gray-300;
-  background: $white;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
   margin-left: auto;
+  background: $white;
+  border: 1px solid $gray-300;
+  border-radius: 0.375rem;
 }
 
 .deleteButton:hover {
@@ -74,9 +74,9 @@
 .content {
   width: 100%;
   padding: 0 1rem;
+  overflow: auto;
   color: $gray-600;
   word-wrap: break-word;
-  overflow: auto;
 
   @include text-lg;
 }

--- a/src/pages/PostPage/UserPost/CardList/CardList.jsx
+++ b/src/pages/PostPage/UserPost/CardList/CardList.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import OutlinedButton from '../../../../components/Button/OutlinedButton';
 import RoundedPlusButton from '../../../../components/Button/RoundedPlusButton';
 import Modal from '../../../../components/Modal/Modal';
 import createAxiosInstance from '../../../../utils/axios';
@@ -10,26 +11,26 @@ import css from './CardList.module.scss';
 const CardList = () => {
   const axios = createAxiosInstance();
   const navigate = useNavigate();
+  const { id } = useParams();
   const [showModal, setShowModal] = useState(false);
   const [messagesList, setMessagesList] = useState([]);
   const [selectedMessageData, setSelectedMessageData] = useState({});
   const [backgroundList, setBackgroundList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [hasNextPage, setHasNextPage] = useState(true);
+  const [backgroundColor, backgroundImageURL] = backgroundList;
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectedMessageIdList, setSelectedMessageIdList] = useState([]);
   const { content, createdAt, font, profileImageURL, relationship, sender } = selectedMessageData;
   const pageSize = 8;
-  const { id } = useParams();
   const messagesDataURL = `recipients/${id}/messages/?limit=${currentPage * pageSize}`;
   const backgroundDataURL = `recipients/${id}/`;
-  const [backgroundColor, backgroundImageURL] = backgroundList;
-
   const backgroundColorList = {
     beige: '#ffe2ad',
     purple: '#ecd9ff',
     blue: '#b1e4ff',
     green: '#d0f5c3',
   };
-
   const backgroundStyle = {
     backgroundImage: `url(${backgroundImageURL})`,
     background: backgroundColorList[backgroundColor],
@@ -78,6 +79,39 @@ const CardList = () => {
     navigate(`/post/${id}/message`);
   };
 
+  const deleteTargetMessage = async id => {
+    try {
+      const deleteApiUrl = `messages/${id}/`;
+      await axios.delete(deleteApiUrl);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleSaveClick = async () => {
+    const isConfirm = confirm('정말 저장하시겠습니까?');
+    if (isConfirm) {
+      for (const id of selectedMessageIdList) {
+        await deleteTargetMessage(id);
+      }
+    }
+    navigate(`/post/${id}`);
+    window.location.reload();
+  };
+
+  const handleDeletePost = async id => {
+    try {
+      const isConfirm = confirm('정말 페이지를 삭제하시겠습니까?');
+      if (isConfirm) {
+        const deleteApiUrl = `recipients/${id}/`;
+        await axios.delete(deleteApiUrl);
+        console.log('페이지 삭제가 완료되었습니다.');
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   useEffect(() => {
     fetchMessagesData(messagesDataURL);
     fetchBackgroundData(backgroundDataURL);
@@ -92,12 +126,54 @@ const CardList = () => {
 
   return (
     <div className={css.cardArea} style={backgroundStyle}>
+      <div className={css.editButtonArea}>
+        {isEditing ? (
+          <>
+            <OutlinedButton
+              size='large'
+              onClick={() => {
+                setIsEditing(false);
+                handleSaveClick();
+                navigate(`/post/${id}`);
+              }}
+            >
+              저장하기
+            </OutlinedButton>
+            <OutlinedButton
+              size='large'
+              onClick={() => {
+                handleDeletePost(id);
+                navigate('/list');
+              }}
+            >
+              페이지 삭제하기
+            </OutlinedButton>
+          </>
+        ) : (
+          <OutlinedButton
+            size='large'
+            onClick={() => {
+              navigate(`/post/${id}/edit`);
+              setIsEditing(true);
+            }}
+          >
+            편집하기
+          </OutlinedButton>
+        )}
+      </div>
       <div className={css.cardBox}>
         <div className={css.card}>
           <RoundedPlusButton onClick={e => handleSendMessageClick(e)} />
         </div>
-        {messagesList?.map((data, idx) => (
-          <Card key={idx} {...data} onClick={() => toggleModal(data)} />
+        {messagesList?.map(data => (
+          <Card
+            key={data.id}
+            {...data}
+            isEditing={isEditing}
+            onClick={() => toggleModal(data)}
+            onAddId={setSelectedMessageIdList}
+            selectedMessageIdList={selectedMessageIdList}
+          />
         ))}
       </div>
       {showModal && (

--- a/src/pages/PostPage/UserPost/CardList/CardList.jsx
+++ b/src/pages/PostPage/UserPost/CardList/CardList.jsx
@@ -94,9 +94,10 @@ const CardList = () => {
       for (const id of selectedMessageIdList) {
         await deleteTargetMessage(id);
       }
+      setIsEditing(false);
+      navigate(`/post/${id}`);
+      window.location.reload();
     }
-    navigate(`/post/${id}`);
-    window.location.reload();
   };
 
   const handleDeletePost = async id => {
@@ -105,7 +106,7 @@ const CardList = () => {
       if (isConfirm) {
         const deleteApiUrl = `recipients/${id}/`;
         await axios.delete(deleteApiUrl);
-        console.log('페이지 삭제가 완료되었습니다.');
+        navigate(`/post/${id}`);
       }
     } catch (error) {
       console.error(error);
@@ -132,9 +133,7 @@ const CardList = () => {
             <OutlinedButton
               size='large'
               onClick={() => {
-                setIsEditing(false);
                 handleSaveClick();
-                navigate(`/post/${id}`);
               }}
             >
               저장하기
@@ -143,7 +142,6 @@ const CardList = () => {
               size='large'
               onClick={() => {
                 handleDeletePost(id);
-                navigate('/list');
               }}
             >
               페이지 삭제하기

--- a/src/pages/PostPage/UserPost/CardList/CardList.jsx
+++ b/src/pages/PostPage/UserPost/CardList/CardList.jsx
@@ -95,8 +95,6 @@ const CardList = () => {
         await deleteTargetMessage(id);
       }
       setIsEditing(false);
-      navigate(`/post/${id}`);
-      window.location.reload();
     }
   };
 
@@ -106,7 +104,6 @@ const CardList = () => {
       if (isConfirm) {
         const deleteApiUrl = `recipients/${id}/`;
         await axios.delete(deleteApiUrl);
-        navigate(`/post/${id}`);
       }
     } catch (error) {
       console.error(error);
@@ -114,9 +111,10 @@ const CardList = () => {
   };
 
   useEffect(() => {
+    if (isEditing) return;
     fetchMessagesData(messagesDataURL);
     fetchBackgroundData(backgroundDataURL);
-  }, []);
+  }, [isEditing]);
 
   useEffect(() => {
     window.addEventListener('scroll', handleScroll);
@@ -151,7 +149,6 @@ const CardList = () => {
           <OutlinedButton
             size='large'
             onClick={() => {
-              navigate(`/post/${id}/edit`);
               setIsEditing(true);
             }}
           >

--- a/src/pages/PostPage/UserPost/CardList/CardList.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/CardList.module.scss
@@ -4,8 +4,8 @@
 .cardArea {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
   flex-grow: 1;
+  gap: 1rem;
   align-items: center;
   width: 100%;
   padding: 3rem 0;

--- a/src/pages/PostPage/UserPost/CardList/CardList.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/CardList.module.scss
@@ -8,7 +8,7 @@
   flex-grow: 1;
   align-items: center;
   width: 100%;
-  padding-top: 3rem;
+  padding: 3rem 0;
 
   .editButtonArea {
     display: flex;
@@ -23,7 +23,6 @@
   flex-wrap: wrap;
   gap: 1.5rem;
   width: 75.2rem;
-  margin: 0 8rem;
 }
 
 .card {

--- a/src/pages/PostPage/UserPost/CardList/CardList.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/CardList.module.scss
@@ -3,9 +3,19 @@
 
 .cardArea {
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
   flex-grow: 1;
-  justify-content: center;
+  align-items: center;
   width: 100%;
+  padding-top: 3rem;
+
+  .editButtonArea {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 1rem;
+    width: 75.2rem;
+  }
 }
 
 .cardBox {
@@ -13,7 +23,7 @@
   flex-wrap: wrap;
   gap: 1.5rem;
   width: 75.2rem;
-  margin: 7rem 8rem 10rem;
+  margin: 0 8rem;
 }
 
 .card {

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -2,18 +2,18 @@
 @import './_variables';
 
 .ql-toolbar {
+  height: 3rem;
+  padding: 0.8rem 1rem;
+  background-color: #eee;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
-  height: 3rem;
-  background-color: #eee;
-  padding: 0.8rem 1rem;
 }
 
 .ql-container {
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
   height: 15.6rem;
   padding: 1rem;
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
 }
 
 strong {


### PR DESCRIPTION
## 주요 변경 사항

+ 기존 Edit 페이지 삭제 및 Edit 기능 CardList 페이지에서 처리
+ 편집하기 버튼 클릭 시 /post/id/edit 페이지 이동
+ edit path에서 카드 선택하여 삭제할 메세지 선택 및 취소 가능
+ 삭제할 카드 모두 선택 후 저장하기 버튼 누르면 수정사항이 반영된 post/id 페이지로 이동
+ 페이지 삭제 버튼 누르면 해당 post/id 롤링페이퍼 삭제


<img width="1342" alt="스크린샷 2024-03-08 오후 11 19 40" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/128225030/3f7cd3c7-b905-4c76-ac6e-60ddf01947ab">
<img width="1290" alt="스크린샷 2024-03-08 오후 11 20 10" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/128225030/ac802576-ae7a-4036-ad9a-8fce4d2f0895">
<img width="1333" alt="스크린샷 2024-03-08 오후 11 20 21" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/128225030/b79bf3ed-c5dd-4573-a7d0-d5fe1e70364f">


# 스타일린트 돌렸더니 자동변환 된 다른 css 파일도 수정사항에 들어갔네요.. 걸러봐주세용..
