### PR TITLE
[#75] refactor: 포스트 페이지 반응형 구현

### DIFF
--- a/src/pages/PostPage/NewPost/NewPost.jsx
+++ b/src/pages/PostPage/NewPost/NewPost.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../../components/Button/Button';
 import ToggleButton from '../../../components/Button/ToggleButton';
@@ -10,8 +10,6 @@ import OptionCardList from './OptionCardList/OptionCardList';
 
 const NewPost = () => {
   const navigate = useNavigate();
-  const fileInputRef = useRef(null);
-
   const [inputValue, setInputValue] = useState('');
   const [selectedButton, setSelectedButton] = useState('color');
   const [selectedOption, setSelectedOption] = useState(0);
@@ -35,14 +33,6 @@ const NewPost = () => {
 
     setSelectedButton('color');
     setCardList(BACKGROUND_COLOR_LIST);
-  };
-
-  const handleImageChange = event => {
-    setCardList([URL.createObjectURL(event.target.files[0]), ...cardList]);
-  };
-
-  const handleUploadButtonClick = () => {
-    fileInputRef.current.click();
   };
 
   const handleSubmit = async event => {
@@ -81,22 +71,6 @@ const NewPost = () => {
           <p className={css.description}>컬러를 선택하거나, 이미지를 선택할 수 있습니다.</p>
           <div className={css.toggleButtonBox}>
             <ToggleButton selectedButton={selectedButton} onClick={handleButtonClick} />
-            {selectedButton === 'image' && (
-              <button
-                type='button'
-                className={css.uploadImageButton}
-                onClick={handleUploadButtonClick}
-              >
-                <input
-                  type='file'
-                  accept='image/*'
-                  style={{ display: 'none' }}
-                  ref={fileInputRef}
-                  onChange={handleImageChange}
-                />
-                나만의 이미지 추가하기
-              </button>
-            )}
           </div>
           <div className={css.cardListBox}>
             <OptionCardList

--- a/src/pages/PostPage/NewPost/NewPost.module.scss
+++ b/src/pages/PostPage/NewPost/NewPost.module.scss
@@ -47,3 +47,10 @@
   @include rounded-2xl;
   @include font-bold;
 }
+
+@media screen and (max-width: $mobile-width) {
+  .layout {
+    width: 100%;
+    padding: 1rem;
+  }
+}

--- a/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.module.scss
+++ b/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.module.scss
@@ -1,5 +1,13 @@
+@import '../../../../styles/index';
+
 .layout {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 0 1.6rem;
+}
+
+@media screen and (max-width: $mobile-width) {
+  .layout {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.module.scss
+++ b/src/pages/PostPage/NewPost/OptionCardList/OptionCardList.module.scss
@@ -3,7 +3,7 @@
 .layout {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 0 1.6rem;
+  gap: 1.6rem;
 }
 
 @media screen and (max-width: $mobile-width) {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -35,3 +35,6 @@ $white: #fff;
 $black: #000;
 $error: #dc3a3a;
 $surface: #f6f8ff;
+
+$tablet-width: 1024px;
+$mobile-width: 768px;


### PR DESCRIPTION
## 요약
- 포스트 페이지 반응형 구현
- 반응형을 위한 변수 추가
## 변경 사항
- 포스트 페에지 반응형 구현
- tablet 
<img width="661" alt="image" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/37425309/46486f03-0a30-4f50-96ff-b1b4dc7c160d">
- mobile
<img width="513" alt="image" src="https://github.com/codeit-sprint4-team9/rolling-paper/assets/37425309/07c1f14f-8c12-4790-a6cd-29f90b5f749a">

- 반응형을 위한 sass 변수 추가

```jsx
// /styles/_variables.scss

//...
$mobile-width: 768px;
$tablet-width: 1024px;

```
##이슈 번호
#75 