### PR TITLE
[#147]fix : 카드 emoji badge 반응형 카드사이즈에 맞춰서 수정 및 카드 스크롤 생기는 부분 수정

### DIFF
--- a/src/components/Badge/BadgeEmoji.jsx
+++ b/src/components/Badge/BadgeEmoji.jsx
@@ -1,8 +1,9 @@
+import { cn } from '../../utils/classNames';
 import css from './BadgeEmoji.module.scss';
 
-const BadgeEmoji = ({ emoji, count }) => {
+const BadgeEmoji = ({ emoji, count, size }) => {
   return (
-    <div className={css.badgeEmoji}>
+    <div className={cn(css.badgeEmoji, size === 'card' && css.badgeEmojiCard)}>
       <div className={css.emoji}>{emoji}</div>
       <div className={css.emojiCount}>{count}</div>
     </div>

--- a/src/components/Badge/BadgeEmoji.module.scss
+++ b/src/components/Badge/BadgeEmoji.module.scss
@@ -2,6 +2,7 @@
 
 .badgeEmoji {
   display: flex;
+  justify-content: center;
   width: 4.5rem;
   gap: 0.5rem;
   padding: 0.5rem 0.7rem;
@@ -12,4 +13,24 @@
   @include rounded-4xl;
   @include text-base;
   @include font-normal;
+}
+
+.badgeEmojiCard {
+  display: flex;
+  justify-content: center;
+  width: 4rem;
+  gap: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  line-height: 20px;
+  color: $white;
+  background: rgb(0 0 0 / 54%);
+
+  @include rounded-4xl;
+  @include text-base;
+  @include font-normal;
+
+  @media (max-width: 767px) {
+    width: 3.8rem;
+    @include text-xs;
+  }
 }

--- a/src/pages/ListPage/Card/Card.jsx
+++ b/src/pages/ListPage/Card/Card.jsx
@@ -39,7 +39,7 @@ const Card = ({
         </div>
         <div className={css.emojiArea}>
           {reactions.slice(0, 3).map(item => (
-            <BadgeEmoji key={item.id} emoji={item.emoji} count={item.count} />
+            <BadgeEmoji key={item.id} emoji={item.emoji} count={item.count} size='card' />
           ))}
         </div>
       </div>

--- a/src/pages/ListPage/Card/Card.module.scss
+++ b/src/pages/ListPage/Card/Card.module.scss
@@ -81,7 +81,7 @@
 .emojiArea {
   width: 100%;
   display: flex;
-  gap: 0.63rem;
+  gap: 0.5rem;
   height: 2.5rem;
   margin-top: 0;
   z-index: 1;

--- a/src/pages/PostPage/UserPost/CardList/Card.module.scss
+++ b/src/pages/PostPage/UserPost/CardList/Card.module.scss
@@ -82,6 +82,7 @@
   overflow: auto;
   color: $gray-600;
   word-wrap: break-word;
+  overflow: hidden;
 
   @include text-lg;
 }


### PR DESCRIPTION
## badge 사이즈 수정 및 카드 스크롤 수정

- 이모지 카운트가 100단위로 나오면 카드 밖으로 나오는 문제 수정했습니다. 
 (카드 사이즈 이모지 배지가 조금 더 작게 만들었습니다)

- 모바일 영역에서 크기 줄여서 밖으로 나오는 문제 수정했습니다
- post된 카드에 스크롤 나오는 문제 수정했습니다.

closes #147