### PR TITLE
[#149] feat: 반응형 웹을 위한 mixin 생성

### DIFF
--- a/src/styles/_media.scss
+++ b/src/styles/_media.scss
@@ -1,0 +1,11 @@
+$breakpoints: (
+  mobile: 'screen and (max-width: 768px)',
+  tablet: 'screen and (min-width: 769px) and (max-width: 1024px)',
+  pc: 'screen and (min-width: 1025px)',
+);
+
+@mixin media($breakpoint) {
+  @media #{map-get($breakpoints, $breakpoint)} {
+    @content;
+  }
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -35,6 +35,3 @@ $white: #fff;
 $black: #000;
 $error: #dc3a3a;
 $surface: #f6f8ff;
-
-$tablet-width: 1024px;
-$mobile-width: 768px;


### PR DESCRIPTION
## 요약
- 반응형 웹을 위한 브레이크 포인트 생성(using mixin)
## 변경 사항
- _meida.scss 임포트해서 사용 `@import '/styles/_media.scss';` 
- 사용 예시
```sass
@import 'styles/_media.scss';
//...
@include media(tablet){
  .layout{
    width: 10rem;
  }
}
```
- 코드 내용
```sass
$breakpoints: (
  mobile: 'screen and (max-width: 768px)',
  tablet: 'screen and (min-width: 769px) and (max-width: 1024px)',
  pc: 'screen and (min-width: 1025px)',
);

@mixin media($breakpoint) {
  @media #{map-get($breakpoints, $breakpoint)} {
    @content;
  }
}

```
## 이슈 번호
#149 