### PR TITLE
[#149] 카드 header(bar)컴포넌트 반응형 수정 & Toast 하단 출력 & share컴포넌트 전달 props명 수정

### DIFF
--- a/src/pages/PostPage/UserPost/Bar/Bar.jsx
+++ b/src/pages/PostPage/UserPost/Bar/Bar.jsx
@@ -24,14 +24,12 @@ const Bar = ({ name = '', messages = [], messageCount = 0 }) => {
       <div className={css.barContents}>
         <WritingCount messages={messages} messageCount={messageCount} />
         <Emoji />
-        <section className={css.shareLayout}>
-          <Share shareList={SHARE_OPTION_LIST} onClick={handleShareSucess} />
-          {showToast && (
-            <div className={css.toastBox}>
-              <Toast onClick={handleToastClose}>URL이 복사되었습니다.</Toast>
-            </div>
-          )}
-        </section>
+        <Share shareList={SHARE_OPTION_LIST} onClick={handleShareSucess} />
+        {showToast && (
+          <div className={css.toastBox}>
+            <Toast onClick={handleToastClose}>URL이 복사되었습니다.</Toast>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/PostPage/UserPost/Bar/Bar.jsx
+++ b/src/pages/PostPage/UserPost/Bar/Bar.jsx
@@ -24,7 +24,7 @@ const Bar = ({ name = '', messages = [], messageCount = 0 }) => {
       <div className={css.barContents}>
         <WritingCount messages={messages} messageCount={messageCount} />
         <Emoji />
-        <Share shareList={SHARE_OPTION_LIST} onClick={handleShareSucess} />
+        <Share shareList={SHARE_OPTION_LIST} onSuccess={handleShareSucess} />
         {showToast && (
           <div className={css.toastBox}>
             <Toast onClick={handleToastClose}>URL이 복사되었습니다.</Toast>

--- a/src/pages/PostPage/UserPost/Bar/Bar.module.scss
+++ b/src/pages/PostPage/UserPost/Bar/Bar.module.scss
@@ -5,7 +5,8 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 1rem 6rem;
+  max-width: 75rem;
+  padding: 1.5rem;
 }
 
 .name {
@@ -15,18 +16,14 @@
 }
 
 .barContents {
-  position: relative;
   display: flex;
   gap: 1.8rem;
   align-items: center;
 }
 
-.shareLayout {
-  position: relative;
-}
-
 .toastBox {
-  position: absolute;
-  right: 0;
-  transform: translate(25%, 25%);
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 1rem;
 }

--- a/src/pages/PostPage/UserPost/Bar/Share.jsx
+++ b/src/pages/PostPage/UserPost/Bar/Share.jsx
@@ -3,7 +3,7 @@ import { SHARE_ICON } from '../../../../constant/constant';
 import useOutsideClick from '../../../../hooks/useOutsideClick';
 import css from './Share.module.scss';
 
-const Share = ({ shareList = [], onClick }) => {
+const Share = ({ shareList = [], onSuccess }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleDropdown = () => {
@@ -13,7 +13,7 @@ const Share = ({ shareList = [], onClick }) => {
   const handleButtonClick = async callback => {
     setIsOpen(false);
     const result = await callback();
-    if (result) onClick();
+    if (result) onSuccess();
   };
 
   const shareRef = useRef(null);


### PR DESCRIPTION
## 요약
- header 컴포넌트 반응형 스타일 수정
- Toast 하단 출력
- Share컴포넌트 전달 props 명 수정
## 변경 사항
- width: 100% + max-width:75rem(1200px) 적용 함으로써 1200px 이후에는 컨텐츠가 고정됨
- Toast 의 position:fixed; 적용 하여 하단에 출력되도록 수정
- Share 컴포넌트의 공유 완료시 실행되는 함수의 props명을 onClick -> onSuccess로 변경
## 이슈 번호
#149